### PR TITLE
Fixed small language-meta.json problems

### DIFF
--- a/src/Languages/language-meta.json
+++ b/src/Languages/language-meta.json
@@ -6,9 +6,9 @@
         "defaultMomentFormat": "MMMM Do YYYY",
         "default": true,
         "aliases": [
-            "English",
             "Anglais",
             "Englais",
+            "US",
             "en",
             "en-us",
             "en_us",
@@ -23,7 +23,7 @@
         "default": false,
         "aliases": [
             "French",
-            "Français",
+            "Francais",
             "France",
             "fr",
             "fr-fr",


### PR DESCRIPTION
- Removed "aliases" that already are the main name of the language
- Added "Francais" with no little "tick" at the bottom of the "c" since most people don't have the will to add it